### PR TITLE
Update config interface of social share button.

### DIFF
--- a/templates/modules/sosial_tools.html
+++ b/templates/modules/sosial_tools.html
@@ -1,60 +1,64 @@
 <div class="social_tools">
 
-    {# Hatena Bookmark #}
-    <a href="http://b.hatena.ne.jp/entry/{{ SITEURL }}/{{ article.url }}" class="hatena-bookmark-button" data-hatena-bookmark-title="{{ SITENAME }}" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加">
-      <img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" />
-    </a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
-    {# Hatena Bookmark END #}
-
-    {# Facebook Like Button #}
-    {% if FACEBOOK_APPID %}
-        <div class="fb-like" data-href="{{ SITEURL }}/{{ article.url }}" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
-    {% endif %}
-    {# Facebook Like Button END #}
-
-    {# Tweet Button #}
-        <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" {%- if TWITTER_ID -%}data-related="{{ TWITTER_ID }}"{%- endif -%}>Tweet</a>
-        <script>
-            !function(d,s,id){
-              var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
-                if(!d.getElementById(id)){
-                  js=d.createElement(s);
-                    js.id=id;
-                    js.src=p+'://platform.twitter.com/widgets.js';
-                    fjs.parentNode.insertBefore(js,fjs);
-                }
-            }(document, 'script', 'twitter-wjs');
-        </script>
-    {# Tweet Button END #}
-
-    {# Google+ Button #}
-        {# +1 ボタン を表示したい位置に次のタグを貼り付けてください。#}
-        <div class="g-plusone "></div>
-
-        {# 最後の +1 ボタン タグの後に次のタグを貼り付けてください。#}
-        <script type="text/javascript">
-          window.___gcfg = {lang: 'ja'};
-          (function() {
-            var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-            po.src = 'https://apis.google.com/js/plusone.js';
-            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-          })();
-        </script>
-    {# Google+ Button END #}
-
-    {# Pocket Button #}
-        <a data-pocket-label="pocket" data-pocket-count="horizontal" class="pocket-btn" data-lang="ja"></a>
-        <script type="text/javascript">
-            !function(d,i){
-              if(!d.getElementById(i)){
-                var j=d.createElement("script");
-                j.id=i;
-                j.src="https://widgets.getpocket.com/v1/j/btn.js?v=1";
-                var w=d.getElementById(i);d.body.appendChild(j);
+    {% for social_service in SOCIAL_SHARE_BUTTONS %}
+      {% if social_service == 'hatebu' %}
+      {# Hatena Bookmark #}
+      <a href="http://b.hatena.ne.jp/entry/{{ SITEURL }}/{{ article.url }}" class="hatena-bookmark-button" data-hatena-bookmark-title="{{ SITENAME }}" data-hatena-bookmark-layout="simple-balloon" title="このエントリーをはてなブックマークに追加">
+        <img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" />
+      </a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+      {# Hatena Bookmark END #}
+      {# Facebook Like Button #}
+      {% elif social_service == 'facebook' %}
+        {% if FACEBOOK_APPID %}
+          <div class="fb-like" data-href="{{ SITEURL }}/{{ article.url }}" data-width="110px" data-layout="button_count" data-action="like" data-show-faces="true" data-share="false"></div>
+        {% endif %}
+      {# Facebook Like Button END #}
+      {# Tweet Button #}
+      {% elif social_service == 'twitter' %}
+      <a href="https://twitter.com/share" class="twitter-share-button addthis_button_tweet" data-lang="ja" {%- if TWITTER_ID -%}data-related="{{ TWITTER_ID }}"{%- endif -%}>Tweet</a>
+      <script>
+          !function(d,s,id){
+            var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
+              if(!d.getElementById(id)){
+                js=d.createElement(s);
+                  js.id=id;
+                  js.src=p+'://platform.twitter.com/widgets.js';
+                  fjs.parentNode.insertBefore(js,fjs);
               }
-            }(document,"pocket-btn-js");
-        </script>
-    {# Pocket Button END #}
+          }(document, 'script', 'twitter-wjs');
+       </script>
+      {# Tweet Button END #}
+      {# Google+ Button #}
+      {% elif social_service == 'googleplus' %}
+          {# +1 ボタン を表示したい位置に次のタグを貼り付けてください。#}
+          <div class="g-plusone "></div>
+
+          {# 最後の +1 ボタン タグの後に次のタグを貼り付けてください。#}
+          <script type="text/javascript">
+            window.___gcfg = {lang: 'ja'};
+            (function() {
+              var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
+              po.src = 'https://apis.google.com/js/plusone.js';
+              var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+            })();
+          </script>
+      {# Google+ Button END #}
+      {# Pocket Button #}
+      {% elif social_service == 'pocket' %}
+          <a data-pocket-label="pocket" data-pocket-count="horizontal" class="pocket-btn" data-lang="ja"></a>
+          <script type="text/javascript">
+              !function(d,i){
+                if(!d.getElementById(i)){
+                  var j=d.createElement("script");
+                  j.id=i;
+                  j.src="https://widgets.getpocket.com/v1/j/btn.js?v=1";
+                  var w=d.getElementById(i);d.body.appendChild(j);
+                }
+              }(document,"pocket-btn-js");
+          </script>
+      {% endif %}
+      {# Pocket Button END #}
+    {% endfor %}
 
 
 </div>


### PR DESCRIPTION
`SOCIAL_SHARE_BUTTONS`: set to use social service names by tuple.
button seted service is shown at footer of blog entry.

If set SHOW_SOCIAL_SHARE_BUTTO to 'True',
You can choice out of 'hatebu', 'twitter', 'facebook', 'googlplus' or 'pocket' all you want.

ex.

if set value as below,

``` py
SOCIAL_SHARE_BUTTONS = ( 'twitter', 'facebook' )
```

shown 'twitter share' and 'facebook link' buttons at footer of blog entry.
