### PR TITLE
Fix can't load javascipt when use https.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Screenshot&Demo
 
-You can see the [my site](http://memo.laughk.org).
+You can see the [my site](https://memo.laughk.org).
 
 ![screenshot_2016-02-02_22-40-31](https://cloud.githubusercontent.com/assets/1286319/12751084/68fcc55c-c9fe-11e5-88eb-e71be612f21f.jpg)
 

--- a/templates/article.html
+++ b/templates/article.html
@@ -36,7 +36,7 @@
         var disqus_identifier = "{{ article.url }}";
         (function() {
              var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-             dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+             dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
          })();
     </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
 <head>
   <!-- ## for client-side less
   <link rel="stylesheet/less" type="text/css" href="{{ SITEURL }}/theme/css/style.less">
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/less.js/1.7.3/less.min.js" type="text/javascript"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.7.3/less.min.js" type="text/javascript"></script>
   -->
   <link rel="icon" type="image/vnd.microsoft.icon" href="{{ SITEURL }}/{{ FAVICON }}">
   <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/style.css">

--- a/templates/modules/sosial_tools.html
+++ b/templates/modules/sosial_tools.html
@@ -34,7 +34,7 @@
       {# Tweet Button #}
       {% elif social_service == 'twitter' %}
       <a class="twitter-share-button"
-         href="http://twitter.com/share?text={{ SITENAME }} - {{ article.title }} | {{ SITEURL }}/{{ article.url }}"
+         href="https://twitter.com/share?text={{ SITENAME }} - {{ article.title }} | {{ SITEURL }}/{{ article.url }}"
          onClick="window.open(encodeURI(decodeURI(this.href)), 'tweetwindow', 'width=650, height=470'); return false;" >
         <i class="fa fa-twitter"></i>
       </a>
@@ -50,7 +50,7 @@
       {# Pocket Button #}
       {% elif social_service == 'pocket' %}
       <a class="pocket-add-button"
-         href="http://getpocket.com/edit?url={{ SITEURL }}/{{ article.url }}&title={{ article.title }}"
+         href="https://getpocket.com/edit?url={{ SITEURL }}/{{ article.url }}&title={{ article.title }}"
          onclick="window.open(this.href, 'add-to-get-pocket', 'width=490,height=530');return false;"
          title="add to pocket" >
         <i class="fa fa-get-pocket"></i>


### PR DESCRIPTION
- replace 'http' to 'htts' about what can be.
- replace 'http' to protocol relative Urls in javascript.
