### PR TITLE
Goodbye Google Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,12 @@ Clone the [repository](https://github.com/laughk/pelican-hss), edit your `pelica
     - `facebook`: [facebook share link](https://developers.facebook.com/docs/sharing/web)
     - `pocket`: [pocket button](https://getpocket.com/publisher/button)
     - `hatebu`: [hatena bookmark](http://b.hatena.ne.jp/guide/bbutton)
-    - `googleplus`: [google plus share button](https://developers.google.com/+/web/share/)
 
   ex.
   ```python
   SHOW_SOCIAL_SHARE_BUTTON = True
   SOCIAL_SHARE_BUTTONS = (
-      'twitter', 'facebook', 'hatebu', 'pocket', 'googleplus'
+      'twitter', 'facebook', 'hatebu', 'pocket',
   )
   ```
 - `CUSTOM_CSS_URL` (Default: `None`)

--- a/templates/base.html
+++ b/templates/base.html
@@ -102,8 +102,6 @@
                 <i class="fab fa-github-square"></i>
               {% elif name == 'facebook' %}
                 <i class="fab fa-facebook-square"></i>
-              {% elif name == 'googleplus' or name == 'google+' %}
-                <i class="fab fa-google-plus-square"></i>
               {% elif name == 'hatebu' %}
                 <i class="fab fa-hatebu-square"></i>
               {% elif name == 'bitbucket' %}

--- a/templates/modules/social-tools.html
+++ b/templates/modules/social-tools.html
@@ -39,13 +39,6 @@
         <i class="fab fa-twitter"></i>
       </a>
       {# Tweet Button END #}
-      {# Google+ Button #}
-      {% elif social_service == 'googleplus' %}
-      <a class="google-plus-share-button"
-         href="https://plus.google.com/share?url={{ SITEURL }}/{{ article.url }}"
-         onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;" >
-        <i class="fab fa-google-plus"></i>
-      </a>
 
       {# Pocket Button #}
       {% elif social_service == 'pocket' %}


### PR DESCRIPTION
ref. https://support.google.com/plus/answer/9217723?hl=en

> Google+ is only available for G Suite accounts through work or school.
> Consumer accounts (typically ending in @gmail.com) were shut down on April 2nd, 2019.