### PR TITLE
fix cannot build category page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 * HSS is responsive and single page design theme for [Pelican](http://getpelican.com), it is my hack of a Giulio Fidente's [gfidente/pelican-svbhack](https://github.com/gfidente/pelican-svbhack) theme.
 * HSS is "H"ack to "S"ingle-page-layout of "S"VBHACK.
 
+:warning: This theme requires Pelican 4.0.0 or newer.
+
 ## Screenshot&Demo
 
 You can see the [my site](https://memo.laughk.org).

--- a/templates/category.html
+++ b/templates/category.html
@@ -3,19 +3,19 @@
 
 {% block head %}
 {% if CATEGORY_FEED_ATOM %}
-<link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} {{ category }} Category Atom" />
+<link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(slug=category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} {{ category }} Category Atom" />
 {% endif %}
 {% if CATEGORY_FEED_RSS %}
-<link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} {{ category }} Category RSS" />
+<link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(slug=category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} {{ category }} Category RSS" />
 {% endif %}
 {% endblock %}
 
 {% block header %}
 &gt; Category: {{ category }}
 {% if CATEGORY_FEED_ATOM %}
-&brvbar; <a href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}">Atom</a>
+&brvbar; <a href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(slug=category.slug) }}">Atom</a>
 {% endif %}
 {% if CATEGORY_FEED_RSS %}
-&brvbar; <a href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category.slug) }}">RSS</a>
+&brvbar; <a href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(slug=category.slug) }}">RSS</a>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
ref. https://github.com/laughk/pelican-hss/issues/55

error message when build pelican blog with this theme and enable category.

```
CRITICAL: TypeError: not all arguments converted during string formatting
```