### PR TITLE
fix: parameter name for index page.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 
 {% block head %}
 
-  {% if TWITTER_CARD %}
+  {% if HSS_TWITTER_CARD %}
   <meta name="twitter:title" content="{{ SITENAME }}" />
   {% endif %}
 


### PR DESCRIPTION
missing metadata `twiter:title` at index page. so fix it. 

## before

![image](https://user-images.githubusercontent.com/1286319/103467857-b7dbca80-4d96-11eb-984a-4e8c0cd233e2.png)

## after

![image](https://user-images.githubusercontent.com/1286319/103470055-8bcd4300-4db0-11eb-99e8-9770b270a955.png)
