### PR TITLE
add options for ogp image

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,26 @@ Clone the [repository](https://github.com/laughk/pelican-hss), edit your `pelica
   ```
 - `HSS_TWITTER_CARD` to enable twitter card for your site. set this var to `True`.
   - `HSS_TWITTER_CARD_TWITTER_ID` twitter_id for TWITTER_CARD, if you want. (optional)
+- `HSS_DEFAULT_OGP_IMAGE_URL` for default ogp image of your site by URL.
 
+
+## How to set an ogp image by articles
+
+if you want to set an ogp image by articles, set below parameters as file metadata.
+
+- `ogp_image_url` (URL): set an url path that you want to use as an ogp image.  
+- `twitter_card_large` (bool, default: false): set "true" if you want to ogp image as "summary_large_image".
+
+ex.
+```markdown
+Title: My super title
+Date: 2022-02-05 10:20
+
+ ... snip ....
+
+ogp_image_url: https://example.com/path/to/your_ogp_image.png
+twitter_card_large: true
+```
 
 ## MODIFICATIONS
 

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -7,6 +7,10 @@
   <meta name="twitter:title" content="{{ SITENAME }} &ndash; Archives" />
   {% endif %}
 
+  {% if HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/templates/article.html
+++ b/templates/article.html
@@ -11,6 +11,15 @@
   <meta name="og:description" content="{{ article.summary|striptags }}" />
   <meta name="keywords" content="{{ article.tags|join(', ')  }}">
 
+  {% if article.ogp_image_url %}
+  <meta property="og:image" content="{{ article.ogp_image_url }}" />
+  {% elif HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+  {% if article.ogp_image_url and article.twitter_card_large %}
+  <meta name="twitter:card" content="summary_large_image" />
+  {% endif %}
+
 {% endblock %}
 
 {% block title %}&ndash; {{ article.title }}{% endblock %}

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -7,6 +7,10 @@
   <meta name="twitter:title" content="{{ SITENAME }} &ndash; Authors" />
   {% endif %}
 
+  {% if HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+
 {% endblock %}
 
 

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -8,6 +8,10 @@
   <meta name="twitter:title" content="{{ SITENAME }} &ndash; Categories" />
   {% endif %}
 
+  {% if HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/templates/category.html
+++ b/templates/category.html
@@ -7,6 +7,10 @@
   <meta name="twitter:title" content="{{ SITENAME }} &ndash; Category" />
   {% endif %}
 
+  {% if HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+
 {% if CATEGORY_FEED_ATOM %}
 <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(slug=category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} {{ category }} Category Atom" />
 {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,10 @@
   <meta name="twitter:title" content="{{ SITENAME }}" />
   {% endif %}
 
+  {% if HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+
 {% endblock %}
 
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -11,6 +11,10 @@
   <meta name="og:title" content="{{ page.title }}" />
   <meta name="og:description" content="{{ page.summary|striptags }}" />
 
+  {% if HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -8,6 +8,10 @@
   <meta name="twitter:title" content="{{ SITENAME }} &ndash; {{ tag }}" />
   {% endif %}
 
+  {% if HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+
 {% if TAG_FEED_ATOM %}
 <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} {{ tag }} Tag Atom" />
 {% endif %}

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -7,6 +7,10 @@
   <meta name="twitter:title" content="{{ SITENAME }} &ndash; Tags" />
   {% endif %}
 
+  {% if HSS_DEFAULT_OGP_IMAGE_URL %}
+  <meta property="og:image" content="{{ HSS_DEFAULT_OGP_IMAGE_URL }}" />
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
# Add below options 

## for pelicanconf.py

- `HSS_DEFAULT_OGP_IMAGE_URL` : for default ogp image

## for content file metadata

- `ogp_image_url` (URL): set an url path that you want to use as an ogp image.  
- `twitter_card_large` (bool, default: false): set "true" if you want to ogp image as "summary_large_image".