### PR TITLE
feat: add social support for mastodon on profile

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -107,7 +107,11 @@
             {% endfor %}
             {% for name, link in SOCIAL %}
             <li>
+              {% if name == 'mastodon' %}
+              <a rel="me" href="{{ link }}" target="_blank" title="{{ name }}">
+              {% else %}
               <a href="{{ link }}" target="_blank" title="{{ name }}">
+              {% endif %}
               {% if name == 'twitter' %}
                 <i class="fab fa-twitter-square"></i>
               {% elif name == 'github' %}
@@ -122,6 +126,8 @@
                 <i class="fab fa-instagram"></i>
               {% elif name == 'linkedin' %}
                 <i class="fab fa-linkedin-square"></i>
+              {% elif name == 'mastodon' %}
+                <i class="fa-brands fa-mastodon"></i>
               {% endif %}
               </a>
             </li>


### PR DESCRIPTION

### example

at pelicanconf.py

```python
SOCIAL = (
    ('twitter', 'https://twitter.com/laugh_k'),
    ('mastodon', 'https://fedibird.com/@laughk'),
    ('github', 'https://github.com/laughk'),
)
```

displayed like below.

![image](https://user-images.githubusercontent.com/1286319/205532146-486dd552-9589-4a30-9963-b31b62613438.png)
 