### PR TITLE
feat: Add x.com support for SOCIAL_SHARE_BUTTONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Clone the [repository](https://github.com/laughk/pelican-hss), edit your `pelica
 
   from the following.
     - `twitter`: [twitter](https://about.twitter.com/ja/resources/buttons)
+    - `x_twitter` : Same as `twitter` except icon and domain.
     - `facebook`: [facebook share link](https://developers.facebook.com/docs/sharing/web)
     - `pocket`: [pocket button](https://getpocket.com/publisher/button)
     - `hatebu`: [hatena bookmark](http://b.hatena.ne.jp/guide/bbutton)
@@ -48,7 +49,7 @@ Clone the [repository](https://github.com/laughk/pelican-hss), edit your `pelica
   ```python
   SHOW_SOCIAL_SHARE_BUTTON = True
   SOCIAL_SHARE_BUTTONS = (
-      'twitter', 'facebook', 'hatebu', 'pocket',
+      'twitter', 'x_twitter', 'facebook', 'hatebu', 'pocket',
   )
   ```
 - `CUSTOM_CSS_URL` (Default: `None`)

--- a/templates/modules/social-tools.html
+++ b/templates/modules/social-tools.html
@@ -40,6 +40,14 @@
       </a>
       {# Tweet Button END #}
 
+      {% elif social_service == 'x_twitter' %}
+      <a class="tweet-blogpost-button"
+         href="https://x.com/share?url={{ SITEURL }}/{{ article.url }}&text={{ SITENAME }} - {{ article.title }}"
+         onClick="window.open(encodeURI(decodeURI(this.href)), 'tweetwindow', 'width=650, height=470'); return false;" >
+        <i class="fab fa-x-twitter"></i>
+      </a>
+      {# X Post Button END #}
+
       {# Pocket Button #}
       {% elif social_service == 'pocket' %}
       <a class="pocket-add-button"


### PR DESCRIPTION
example

add a string `x_twitter` to `SOCIAL_SHARE_BUTTONS` in pelicanconf.py. The icon will appear as follows.

![image](https://github.com/laughk/pelican-hss/assets/1286319/bd5f1c1f-ee73-4f60-a67b-34471944acb0)
